### PR TITLE
Simplify POST request body with single-quotes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -139,7 +139,7 @@ $ curl http://localhost:8080/people
 There are currently no elements and hence no pages. Time to create a new `Person`!
 
 ```
-$ curl -i -X POST -H "Content-Type:application/json" -d "{  \"firstName\" : \"Frodo\",  \"lastName\" : \"Baggins\" }" http://localhost:8080/people
+$ curl -i -X POST -H "Content-Type:application/json" -d '{"firstName": "Frodo", "lastName": "Baggins"}' http://localhost:8080/people
 HTTP/1.1 201 Created
 Server: Apache-Coyote/1.1
 Location: http://localhost:8080/people/1
@@ -150,7 +150,7 @@ Date: Wed, 26 Feb 2014 20:26:55 GMT
 - `-i` ensures you can see the response message including the headers. The URI of the newly created `Person` is shown
 - `-X POST` signals this a POST used to create a new entry
 - `-H "Content-Type:application/json"` sets the content type so the application knows the payload contains a JSON object
-- `-d "{  \"firstName\" : \"Frodo\",  \"lastName\" : \"Baggins\" }"` is the data being sent. Double quotes inside the data need to be escaped as `\"`.
+- `-d '{"firstName": "Frodo", "lastName": "Baggins"}'` is the data being sent
 
 NOTE: Notice how the previous `POST` operation includes a `Location` header. This contains the URI of the newly created resource. Spring Data REST also has two methods on `RepositoryRestConfiguration.setReturnBodyOnCreate(…)` and `setReturnBodyOnUpdate(…)` which you can use to configure the framework to immediately return the representation of the resource just created. `RepositoryRestConfiguration.setReturnBodyForPutAndPost(…)` is a short cut method to enable representation responses for creates and updates.
 


### PR DESCRIPTION
No need to escape double quotes now