### PR TITLE
Remove duplicated paragraphs and tidy a header

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,11 +78,7 @@ include::complete/src/main/java/com/example/accessingdatarest/Person.java[]
 The `Person` object has a first name and a last name. (There is also an ID object that is
 configured to be automatically generated, so you need not deal with that.)
 
-This repository is an interface and will allow you to perform various operations involving `Person` objects. It gets these operations by extending the https://docs.spring.io/spring-data/commons/docs/{spring_data_commons}/api/org/springframework/data/repository/PagingAndSortingRepository.html[PagingAndSortingRepository] interface defined in Spring Data Commons.
-
-At runtime, Spring Data REST will create an implementation of this interface automatically. Then it will use the https://docs.spring.io/spring-data/rest/docs/{spring_data_rest}/api/org/springframework/data/rest/core/annotation/RepositoryRestResource.html[@RepositoryRestResource] annotation to direct Spring MVC to create RESTful endpoints at `/people`.
-
-== Create a Person repository
+== Create a Person Repository
 
 Next, you need to create a simple repository, as the following listing (in
   `src/main/java/com/example/accessingdatarest/PersonRepository.java`) shows:


### PR DESCRIPTION
A couple of paragraphs appear in "Create a Domain Object" earlier than they should and are duplicated in "Create a Person repository" where it should be.

Tidied Create a Person Repository header.