### PR TITLE
fix: not found junit-platform-launcher:1.6.2 for test codes

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -44,6 +44,12 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<!-- this is needed or IntelliJ gives junit.jar or junit-platform-launcher:1.6.2 not found errors -->
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
AccessingDataRestApplicationTests compiled failed when do test on IDEA Community 2020.1.4, which report 'not found junit-platform-launcher:1.6.2'.